### PR TITLE
Add rqrcode as a dependancy

### DIFF
--- a/fastlane-plugin-niels.gemspec
+++ b/fastlane-plugin-niels.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'rqrcode'
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')


### PR DESCRIPTION
When you want to use a gem in another gem, then you'll have to add the dependency in the gem's `gemspec`

P.S. I love your creativity btw!